### PR TITLE
Deprecated in Symfony 4.1

### DIFF
--- a/Resources/config/routing_edit_in_place.yml
+++ b/Resources/config/routing_edit_in_place.yml
@@ -1,4 +1,4 @@
 translation_edit_in_place_update:
     path: /_trans_edit_in_place/{configName}/{locale}
     methods: [POST]
-    defaults:  { _controller: TranslationBundle:EditInPlace:edit }
+    defaults:  { _controller: Translation\Bundle\Controller\EditInPlaceController::editAction }


### PR DESCRIPTION
User Deprecated: Referencing controllers with TranslationBundle:EditInPlace:edit is deprecated since Symfony 4.1